### PR TITLE
Update Entity.css

### DIFF
--- a/src/components/Entity.css
+++ b/src/components/Entity.css
@@ -14,6 +14,7 @@
 
 .cl-entity-node {
     position: relative;
+    display: inline-flex;
 }
 
 .cl-entity-node__text {


### PR DESCRIPTION
Will fix multine span when the label stays on the fist line but the selected text goes to the second line.